### PR TITLE
Fix: Removeable Apple apps with ShortVersion not showing in apps list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 - “Developer Mode” is no longer required.
 - Now you can access “iCloud Drive” from TrollFools.
+- Removeable Apple apps with no version defined now show

--- a/TrollFools/AppListView.swift
+++ b/TrollFools/AppListView.swift
@@ -161,7 +161,7 @@ final class AppListModel: ObservableObject {
                       let teamID = proxy.teamID(),
                       let appType = proxy.applicationType(),
                       let localizedName = proxy.localizedName(),
-                      let shortVersionString = proxy.shortVersionString()
+                      let shortVersionString: String? = proxy.shortVersionString()
                 else {
                     return nil
                 }

--- a/TrollFools/Version.Debug.xcconfig
+++ b/TrollFools/Version.Debug.xcconfig
@@ -9,4 +9,4 @@
 // https://help.apple.com/xcode/#/dev745c5c974
 
 DEBUG_VERSION = 2.6
-DEBUG_BUILD_NUMBER = 202408191
+DEBUG_BUILD_NUMBER = 202409091

--- a/TrollFools/Version.xcconfig
+++ b/TrollFools/Version.xcconfig
@@ -9,4 +9,4 @@
 // https://help.apple.com/xcode/#/dev745c5c974
 
 VERSION = 2.6
-BUILD_NUMBER = 6
+BUILD_NUMBER = 7

--- a/layout/DEBIAN/control
+++ b/layout/DEBIAN/control
@@ -1,6 +1,6 @@
 Package: wiki.qaq.trollfools
 Name: TrollFools
-Version: 2.6-6
+Version: 2.6-7
 Section: Applications
 Depends: firmware (>= 14.0)
 Architecture: iphoneos-arm


### PR DESCRIPTION
Apps with no ShortVersion property in bundle's Info.plist won't show in Apps list, also some apps like Clock with identifier com.apple.mobiletimer can indeed work with injected dylibs.