### PR TITLE
Autocorrect disabled

### DIFF
--- a/TrollFools/AppListView.swift
+++ b/TrollFools/AppListView.swift
@@ -596,6 +596,7 @@ struct AppListView: View {
                                  : NSLocalizedString("Search…", comment: ""))
                     )
                     .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
             } else {
                 // Fallback on earlier versions
                 appList


### PR DESCRIPTION
The auto-correction for the app search has been disabled. Without this change, it was previously possible to be thrown back into the search after selecting an app from the OptionView, because the auto-correction could change the search term entered after selecting the app.