### PR TITLE
Bump `MachOKit` to 0.26.2

### DIFF
--- a/TrollFools.xcodeproj/project.pbxproj
+++ b/TrollFools.xcodeproj/project.pbxproj
@@ -663,7 +663,7 @@
 			repositoryURL = "https://github.com/p-x9/MachOKit.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.19.0;
+				minimumVersion = 0.26.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/TrollFools.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TrollFools.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,26 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/p-x9/MachOKit.git",
       "state" : {
-        "revision" : "55a08c5ce8a9115c279a25d17349753a520fb474",
-        "version" : "0.19.0"
+        "revision" : "a0f42bcf3ed105c4e442131990702bad2807c549",
+        "version" : "0.26.2"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "7faebca1ea4f9aaf0cda1cef7c43aecd2311ddf6",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "ff0f781cf7c6a22d52957e50b104f5768b50c779",
+        "version" : "3.10.0"
       }
     },
     {


### PR DESCRIPTION
Hello
I am a developer of a library named MachOKit

I have found a critical issue with MachOKit that occurs during Release builds in Swift 6 and later.
- https://github.com/p-x9/MachOKit/pull/160

Therefore, the version is updated to the latest version.

Version 0.19.0 has been used up to now, and includes several minor fixes, performance improvements, and feature additions in addition to the fixes in this issue.
- https://github.com/p-x9/MachOKit/compare/0.19.0...0.26.2