### PR TITLE
refactor: enhance framework Mach-O retrieval methods

### DIFF
--- a/TrollFools/InjectorV3+Bundle.swift
+++ b/TrollFools/InjectorV3+Bundle.swift
@@ -36,19 +36,15 @@ extension InjectorV3 {
 
     // MARK: - Shared Methods
 
-    func frameworkMachOsInBundle(_ target: URL) throws -> OrderedSet<URL> {
+    func allFrameworkMachOsInBundle(_ target: URL) -> OrderedSet<URL> {
         precondition(checkIsBundle(target), "Not a bundle: \(target.path)")
 
-        let executableURL = try locateExecutableInBundle(target)
-        precondition(isMachO(executableURL), "Not a Mach-O: \(executableURL.path)")
-
         let frameworksURL = target.appendingPathComponent("Frameworks")
-        let linkedDylibs = try linkedDylibsRecursivelyOfMachO(executableURL)
 
         var enumeratedURLs = OrderedSet<URL>()
         if let enumerator = FileManager.default.enumerator(
             at: frameworksURL,
-            includingPropertiesForKeys: [.fileSizeKey],
+            includingPropertiesForKeys: [.isRegularFileKey],
             options: [.skipsHiddenFiles]
         ) {
             for case let itemURL as URL in enumerator {
@@ -56,11 +52,27 @@ extension InjectorV3 {
                     enumerator.skipDescendants()
                     continue
                 }
-                if enumerator.level == 2 {
+                if enumerator.level == 2,
+                   isMachO(itemURL),
+                   !itemURL.lastPathComponent.hasSuffix(".\(Self.injectedMarkerName).bak"),
+                   !itemURL.lastPathComponent.hasSuffix(".troll-fools.bak")
+                {
                     enumeratedURLs.append(itemURL)
                 }
             }
         }
+
+        return enumeratedURLs
+    }
+
+    func frameworkMachOsInBundle(_ target: URL) throws -> OrderedSet<URL> {
+        precondition(checkIsBundle(target), "Not a bundle: \(target.path)")
+
+        let executableURL = try locateExecutableInBundle(target)
+        precondition(isMachO(executableURL), "Not a Mach-O: \(executableURL.path)")
+
+        let linkedDylibs = try linkedDylibsRecursivelyOfMachO(executableURL)
+        let enumeratedURLs = allFrameworkMachOsInBundle(target)
 
         let machOs = linkedDylibs.intersection(enumeratedURLs)
         var sortedMachOs: [URL] =

--- a/TrollFools/InjectorV3+Eject.swift
+++ b/TrollFools/InjectorV3+Eject.swift
@@ -94,7 +94,14 @@ extension InjectorV3 {
     }
 
     fileprivate func collectModifiedMachOs() throws -> [URL] {
-        try frameworkMachOsInBundle(bundleURL)
+        let preferredMachOs = try frameworkMachOsInBundle(bundleURL)
+            .filter { hasAlternate($0) }.elements
+        if !preferredMachOs.isEmpty {
+            return preferredMachOs
+        }
+
+        DDLogWarn("Fallback to traversal strategy", ddlog: logger)
+        return allFrameworkMachOsInBundle(bundleURL)
             .filter { hasAlternate($0) }.elements
     }
 

--- a/TrollFools/InjectorV3+Inject.swift
+++ b/TrollFools/InjectorV3+Inject.swift
@@ -205,7 +205,14 @@ extension InjectorV3 {
     // MARK: - Path Finder
 
     fileprivate func locateAvailableMachO() throws -> URL? {
-        try frameworkMachOsInBundle(bundleURL)
+        let preferredMachO = try frameworkMachOsInBundle(bundleURL)
+            .first { try !isProtectedMachO($0) }
+        if let preferredMachO {
+            return preferredMachO
+        }
+
+        DDLogWarn("Fallback to traversal strategy", ddlog: logger)
+        return try allFrameworkMachOsInBundle(bundleURL)
             .first { try !isProtectedMachO($0) }
     }
 

--- a/TrollFools/Version.Debug.xcconfig
+++ b/TrollFools/Version.Debug.xcconfig
@@ -9,4 +9,4 @@
 // https://help.apple.com/xcode/#/dev745c5c974
 
 DEBUG_VERSION = 4.2
-DEBUG_BUILD_NUMBER = 202509122
+DEBUG_BUILD_NUMBER = 20260327

--- a/TrollFools/Version.xcconfig
+++ b/TrollFools/Version.xcconfig
@@ -9,4 +9,4 @@
 // https://help.apple.com/xcode/#/dev745c5c974
 
 VERSION = 4.2
-BUILD_NUMBER = 227
+BUILD_NUMBER = 228


### PR DESCRIPTION
Refactor Mach-O scanning logic to correctly handle apps 
that are allowed in the whitelist but fail injection 
because the main executable does not directly link them.