### PR TITLE
fix: support injection into Unity apps with dynamically loaded frameworks

### DIFF
--- a/TrollFools/InjectorV3+Bundle.swift
+++ b/TrollFools/InjectorV3+Bundle.swift
@@ -43,9 +43,16 @@ extension InjectorV3 {
         precondition(isMachO(executableURL), "Not a Mach-O: \(executableURL.path)")
 
         let frameworksURL = target.appendingPathComponent("Frameworks")
+        let frameworksExist = FileManager.default.fileExists(atPath: frameworksURL.path)
+
+        DDLogInfo("Scanning Mach-Os in \(target.lastPathComponent), Frameworks exists: \(frameworksExist)", ddlog: logger)
+
         let linkedDylibs = try linkedDylibsRecursivelyOfMachO(executableURL)
+        DDLogInfo("Linked dylibs (\(linkedDylibs.count)): \(linkedDylibs.map { $0.lastPathComponent })", ddlog: logger)
 
         var enumeratedURLs = OrderedSet<URL>()
+        var allMachOsInFrameworks = OrderedSet<URL>()
+
         if let enumerator = FileManager.default.enumerator(
             at: frameworksURL,
             includingPropertiesForKeys: [.fileSizeKey],
@@ -58,11 +65,30 @@ extension InjectorV3 {
                 }
                 if enumerator.level == 2 {
                     enumeratedURLs.append(itemURL)
+                    if isMachO(itemURL) {
+                        allMachOsInFrameworks.append(itemURL)
+                    }
+                }
+                // Scan bare dylibs at level 1 (directly in Frameworks/)
+                if enumerator.level == 1 && itemURL.pathExtension.lowercased() == "dylib" && isMachO(itemURL) {
+                    allMachOsInFrameworks.append(itemURL)
+                    enumeratedURLs.append(itemURL)
                 }
             }
         }
 
-        let machOs = linkedDylibs.intersection(enumeratedURLs)
+        DDLogInfo("Enumerated \(enumeratedURLs.count) items, \(allMachOsInFrameworks.count) Mach-Os in Frameworks/", ddlog: logger)
+
+        var machOs = linkedDylibs.intersection(enumeratedURLs)
+        DDLogInfo("Intersection: \(machOs.count) linked Mach-Os in Frameworks/", ddlog: logger)
+
+        // Fallback: if none of the Mach-Os in Frameworks/ are statically linked
+        // by the main binary (e.g. Unity apps use dlopen), use all available Mach-Os.
+        if machOs.isEmpty && !allMachOsInFrameworks.isEmpty {
+            DDLogWarn("No statically linked Mach-Os found, falling back to all \(allMachOsInFrameworks.count) Mach-Os in Frameworks/", ddlog: logger)
+            machOs = allMachOsInFrameworks
+        }
+
         var sortedMachOs: [URL] =
             switch injectStrategy {
         case .lexicographic:

--- a/TrollFools/InjectorV3+Inject.swift
+++ b/TrollFools/InjectorV3+Inject.swift
@@ -210,25 +210,36 @@ extension InjectorV3 {
         DDLogInfo("Mach-O scan: \(allMachOs.count) candidates in \(bundleURL.lastPathComponent)", ddlog: logger)
 
         var selectedMachO: URL?
+        var encryptedCount = 0
+        var unreadableCount = 0
         for (index, machO) in allMachOs.enumerated() {
-            let isProtected = (try? isProtectedMachO(machO)) ?? true
             let fileSize = (try? machO.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
             let sizeStr = ByteCountFormatter.string(fromByteCount: Int64(fileSize), countStyle: .file)
 
-            if isProtected {
-                DDLogInfo("  [\(index + 1)/\(allMachOs.count)] ENCRYPTED \(machO.lastPathComponent) (\(sizeStr))", ddlog: logger)
-            } else {
-                DDLogInfo("  [\(index + 1)/\(allMachOs.count)] AVAILABLE \(machO.lastPathComponent) (\(sizeStr))", ddlog: logger)
-                if selectedMachO == nil {
-                    selectedMachO = machO
+            do {
+                let isProtected = try isProtectedMachO(machO)
+                if isProtected {
+                    encryptedCount += 1
+                    DDLogInfo("  [\(index + 1)/\(allMachOs.count)] ENCRYPTED \(machO.lastPathComponent) (\(sizeStr))", ddlog: logger)
+                } else {
+                    DDLogInfo("  [\(index + 1)/\(allMachOs.count)] AVAILABLE \(machO.lastPathComponent) (\(sizeStr))", ddlog: logger)
+                    if selectedMachO == nil {
+                        selectedMachO = machO
+                    }
                 }
+            } catch {
+                unreadableCount += 1
+                DDLogError("  [\(index + 1)/\(allMachOs.count)] UNREADABLE \(machO.lastPathComponent) (\(sizeStr)): \(error)", ddlog: logger)
             }
         }
 
         if let selected = selectedMachO {
             DDLogInfo("Selected Mach-O: \(selected.lastPathComponent)", ddlog: logger)
         } else {
-            DDLogError("No available Mach-O found, all \(allMachOs.count) candidates are encrypted", ddlog: logger)
+            DDLogError(
+                "No available Mach-O found: \(encryptedCount) encrypted, \(unreadableCount) unreadable, \(allMachOs.count - encryptedCount - unreadableCount) unavailable",
+                ddlog: logger
+            )
         }
 
         return selectedMachO

--- a/TrollFools/InjectorV3+Inject.swift
+++ b/TrollFools/InjectorV3+Inject.swift
@@ -205,8 +205,33 @@ extension InjectorV3 {
     // MARK: - Path Finder
 
     fileprivate func locateAvailableMachO() throws -> URL? {
-        try frameworkMachOsInBundle(bundleURL)
-            .first { try !isProtectedMachO($0) }
+        let allMachOs = try frameworkMachOsInBundle(bundleURL)
+
+        DDLogInfo("Mach-O scan: \(allMachOs.count) candidates in \(bundleURL.lastPathComponent)", ddlog: logger)
+
+        var selectedMachO: URL?
+        for (index, machO) in allMachOs.enumerated() {
+            let isProtected = (try? isProtectedMachO(machO)) ?? true
+            let fileSize = (try? machO.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+            let sizeStr = ByteCountFormatter.string(fromByteCount: Int64(fileSize), countStyle: .file)
+
+            if isProtected {
+                DDLogInfo("  [\(index + 1)/\(allMachOs.count)] ENCRYPTED \(machO.lastPathComponent) (\(sizeStr))", ddlog: logger)
+            } else {
+                DDLogInfo("  [\(index + 1)/\(allMachOs.count)] AVAILABLE \(machO.lastPathComponent) (\(sizeStr))", ddlog: logger)
+                if selectedMachO == nil {
+                    selectedMachO = machO
+                }
+            }
+        }
+
+        if let selected = selectedMachO {
+            DDLogInfo("Selected Mach-O: \(selected.lastPathComponent)", ddlog: logger)
+        } else {
+            DDLogError("No available Mach-O found, all \(allMachOs.count) candidates are encrypted", ddlog: logger)
+        }
+
+        return selectedMachO
     }
 
     fileprivate static func findResource(_ name: String, fileExtension: String) -> URL {


### PR DESCRIPTION
Unity-based apps (e.g. Arena of Valor) do not statically link their frameworks via LC_LOAD_DYLIB. Instead, they load frameworks at runtime using dlopen(). This caused frameworkMachOsInBundle() to return an empty intersection, leaving only the main executable (which is typically encrypted) as a candidate.

Changes:
- Add fallback in frameworkMachOsInBundle(): when the intersection of linked dylibs and enumerated Frameworks/ is empty, use all valid Mach-O files found in Frameworks/ as candidates.
- Also scan bare .dylib files at level 1 in Frameworks/.
- Add detailed logging in locateAvailableMachO() to report each candidate's encryption status and file size for easier debugging.